### PR TITLE
Fix 32-bit JVM crash

### DIFF
--- a/BeranaUI/src/com/beranabyte/ui/customdecoration/CustomDecorationWindowProc.java
+++ b/BeranaUI/src/com/beranabyte/ui/customdecoration/CustomDecorationWindowProc.java
@@ -24,7 +24,10 @@ public class CustomDecorationWindowProc implements WinUser.WindowProc {
 
    public void init(WinDef.HWND hwnd) {
       this.hwnd = hwnd;
-      defWndProc = INSTANCEEx.SetWindowLongPtr(hwnd, User32Ex.GWLP_WNDPROC, this);
+      if(is64Bit())
+         defWndProc=INSTANCEEx.SetWindowLongPtr(hwnd, User32Ex.GWLP_WNDPROC, this);
+      else
+         defWndProc=INSTANCEEx.SetWindowLong(hwnd, User32Ex.GWLP_WNDPROC, this);
       INSTANCEEx.SetWindowPos(hwnd, hwnd, 0, 0, 0, 0,
               SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
    }
@@ -42,7 +45,10 @@ public class CustomDecorationWindowProc implements WinUser.WindowProc {
             }
             return lresult;
          case WM_DESTROY:
-            INSTANCEEx.SetWindowLongPtr(hwnd, User32Ex.GWLP_WNDPROC, defWndProc);
+            if(is64Bit())
+               INSTANCEEx.SetWindowLongPtr(hwnd, User32Ex.GWLP_WNDPROC, defWndProc);
+            else
+               INSTANCEEx.SetWindowLong(hwnd, User32Ex.GWLP_WNDPROC, defWndProc);
             return new LRESULT(0);
          default:
             lresult = INSTANCEEx.CallWindowProc(defWndProc, hwnd, uMsg, wparam, lparam);
@@ -90,5 +96,16 @@ public class CustomDecorationWindowProc implements WinUser.WindowProc {
       };
 
       return new LRESULT(hitTests[uRow][uCol]);
+   }
+
+   public static final boolean is64Bit()
+   {
+      String model=System.getProperty("sun.arch.data.model",
+              System.getProperty("com.ibm.vm.bitmode"));
+      if(model != null)
+      {
+         return "64".equals(model);
+      }
+      return false;
    }
 }

--- a/BeranaUI/src/com/beranabyte/ui/customdecoration/User32Ex.java
+++ b/BeranaUI/src/com/beranabyte/ui/customdecoration/User32Ex.java
@@ -5,6 +5,8 @@ import com.sun.jna.platform.win32.User32;
 
 interface User32Ex extends User32 {
    int GWLP_WNDPROC = -4;
+   LONG_PTR SetWindowLong(HWND hWnd, int nIndex, WindowProc wndProc);
+   LONG_PTR SetWindowLong(HWND hWnd, int nIndex, LONG_PTR wndProc);
    LONG_PTR SetWindowLongPtr(HWND hWnd, int nIndex, WindowProc wndProc);
    LONG_PTR SetWindowLongPtr(HWND hWnd, int nIndex, LONG_PTR wndProc);
    LRESULT CallWindowProc(LONG_PTR proc, HWND hWnd, int uMsg, WPARAM uParam, LPARAM lParam);

--- a/CustomDecoratedJFrame.iml
+++ b/CustomDecoratedJFrame.iml
@@ -3,10 +3,12 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/TestDemo/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/BeranaUI/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/BeranaUIDemo/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/BeranaUIDemo/src" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="lib" level="project" />
   </component>
 </module>


### PR DESCRIPTION
On 32-bit JVM, SetWindowLongPtr causes a link error. The function is actually just a wrapper for SetWindowLong on 32-bit ( https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlongptra )